### PR TITLE
fix: correct config folder path for Hydra initialization

### DIFF
--- a/notebooks/example_ner_notebook.ipynb
+++ b/notebooks/example_ner_notebook.ipynb
@@ -55,7 +55,7 @@
    "outputs": [],
    "source": [
     "data_path = \"../data\"\n",
-    "with initialize(version_base=None, config_path=\"conf\"):\n",
+    "with initialize(version_base=None, config_path=\"../conf\"):\n",
     "    cfg = compose(\n",
     "        config_name=\"config\",\n",
     "        overrides=[\n",


### PR DESCRIPTION
- Updated the `config_path` argument in the Hydra `initialize` function to point to the correct directory (`conf` folder).
- Resolved `MissingConfigException` due to incorrect path.